### PR TITLE
Remove margin on compact grid

### DIFF
--- a/src/_base.scss
+++ b/src/_base.scss
@@ -35,7 +35,7 @@
     box-sizing: border-box;
     display: inline-block;
     width: 100%;
-    margin: 0 -.25em 0 0;
+    margin: 0 -4px 0 0;
     padding: 0 0 0 $gr-gutter;
     direction: $gr-item-direction;
     text-align: $gr-item-align-x;

--- a/src/_modifiers.scss
+++ b/src/_modifiers.scss
@@ -32,6 +32,7 @@
 
     > .#{$gr-item} {
         padding: 0;
+        margin: 0;
     }
 }
 

--- a/src/_modifiers.scss
+++ b/src/_modifiers.scss
@@ -32,7 +32,6 @@
 
     > .#{$gr-item} {
         padding: 0;
-        margin: 0;
     }
 }
 


### PR DESCRIPTION
Removed margin on grid items when using compact grid. However, it required me to use comments to remove whitespace between elements. Could be to do with my reset method? (Just using normalize).
